### PR TITLE
Add buy & rent providers to Film details page

### DIFF
--- a/src/components/Film.css
+++ b/src/components/Film.css
@@ -87,13 +87,13 @@ film
 .rent__providers {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 5px;
 }
 
 .buy__providers img,
 .stream__providers img,
 .rent__providers img {
-  width: 40px;
+  width: 30px;
 }
 
 .back__button {

--- a/src/components/Film.css
+++ b/src/components/Film.css
@@ -81,12 +81,18 @@ film
   max-width: 500px;
 }
 
-.film__providers {
+.film__providers,
+.buy__providers,
+.stream__providers,
+.rent__providers {
   display: flex;
-  gap: 15px;
+  flex-wrap: wrap;
+  gap: 10px;
 }
 
-.film__providers img {
+.buy__providers img,
+.stream__providers img,
+.rent__providers img {
   width: 40px;
 }
 

--- a/src/components/Film.tsx
+++ b/src/components/Film.tsx
@@ -120,15 +120,15 @@ const Film = () => {
             <span className='helper__blue'>Runtime: </span>
             {convertRunTime(filmData.runtime)}
           </div>
-          <div className='film__minor-info'>
-            <span className='helper__blue'>Watch on: </span>
-          </div>
 
           {watchProviders ? 
 
-          <div>
+          <div className='film__providers'>
+            <div className='film__minor-info'>
+              <span className='helper__blue'>Stream: </span>
+            </div>
+
             <div className='stream__providers'>
-            <span className='helper__blue'>Stream: </span>
             {watchProviders.flatrate.map((provider: any) => (
               <img
                 key={provider.provider_id}
@@ -139,7 +139,9 @@ const Film = () => {
             </div>
 
           <div className='buy__providers'>
-          <span className='helper__blue'>Buy: </span>
+            <div className='film__minor-info'>
+              <span className='helper__blue'>Buy: </span>
+            </div>
           {watchProviders.buy.map((provider: any) => (
             <img
               key={provider.provider_id}
@@ -149,8 +151,10 @@ const Film = () => {
           ))}
           </div>
 
-          <div className='rent_providers'>
-          <span className='helper__blue'>Rent: </span>
+          <div className='rent__providers'>
+            <div className='film__minor-info'>
+              <span className='helper__blue'>Rent: </span>
+            </div>
           {watchProviders.rent.map((provider: any) => (
             <img
               key={provider.provider_id}

--- a/src/components/Film.tsx
+++ b/src/components/Film.tsx
@@ -1,4 +1,3 @@
-import { fi } from 'date-fns/locale';
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import apiKey from '../apiKey';
@@ -52,7 +51,7 @@ const Film = () => {
       .then((response) => response.json())
       .then(async (data) => {
         if (!cancelled) {
-          setWatchProviders(data.results.GB.flatrate); // .GB === country, .flatrate === streaming
+          setWatchProviders(data.results.GB); // .GB === country
         }
       });
 
@@ -61,6 +60,8 @@ const Film = () => {
       }
       
   }, [filmData]);
+
+  console.log(watchProviders)
 
   // GET similar films
   useEffect(() => {
@@ -125,8 +126,21 @@ const Film = () => {
 
           {watchProviders ? 
 
-          <div className='film__providers'>
-          {watchProviders.map((provider: any) => (
+          <div>
+            <div className='stream__providers'>
+            <span className='helper__blue'>Stream: </span>
+            {watchProviders.flatrate.map((provider: any) => (
+              <img
+                key={provider.provider_id}
+                src={getIconURL(provider.logo_path)}
+                alt={provider.provider_name + ' logo'}
+              />
+            ))}
+            </div>
+
+          <div className='buy__providers'>
+          <span className='helper__blue'>Buy: </span>
+          {watchProviders.buy.map((provider: any) => (
             <img
               key={provider.provider_id}
               src={getIconURL(provider.logo_path)}
@@ -134,6 +148,19 @@ const Film = () => {
             />
           ))}
           </div>
+
+          <div className='rent_providers'>
+          <span className='helper__blue'>Rent: </span>
+          {watchProviders.rent.map((provider: any) => (
+            <img
+              key={provider.provider_id}
+              src={getIconURL(provider.logo_path)}
+              alt={provider.provider_name + ' logo'}
+            />
+          ))}
+          </div>
+
+        </div>
 
           : "Not currently available to stream."}
 

--- a/src/components/Film.tsx
+++ b/src/components/Film.tsx
@@ -124,11 +124,12 @@ const Film = () => {
           {watchProviders ? 
 
           <div className='film__providers'>
-            <div className='film__minor-info'>
-              <span className='helper__blue'>Stream: </span>
-            </div>
 
+            {watchProviders.flatrate &&
             <div className='stream__providers'>
+              <div className='film__minor-info'>
+                <span className='helper__blue'>Stream: </span>
+              </div>
             {watchProviders.flatrate.map((provider: any) => (
               <img
                 key={provider.provider_id}
@@ -138,31 +139,40 @@ const Film = () => {
             ))}
             </div>
 
-          <div className='buy__providers'>
-            <div className='film__minor-info'>
-              <span className='helper__blue'>Buy: </span>
-            </div>
-          {watchProviders.buy.map((provider: any) => (
-            <img
-              key={provider.provider_id}
-              src={getIconURL(provider.logo_path)}
-              alt={provider.provider_name + ' logo'}
-            />
-          ))}
-          </div>
+            } 
 
-          <div className='rent__providers'>
-            <div className='film__minor-info'>
-              <span className='helper__blue'>Rent: </span>
+            {watchProviders.buy && 
+              <div className='buy__providers'>
+              <div className='film__minor-info'>
+                <span className='helper__blue'>Buy: </span>
+              </div>
+            {watchProviders.buy.map((provider: any) => (
+              <img
+                key={provider.provider_id}
+                src={getIconURL(provider.logo_path)}
+                alt={provider.provider_name + ' logo'}
+              />
+            ))}
             </div>
-          {watchProviders.rent.map((provider: any) => (
-            <img
-              key={provider.provider_id}
-              src={getIconURL(provider.logo_path)}
-              alt={provider.provider_name + ' logo'}
-            />
-          ))}
-          </div>
+            }
+
+
+            {watchProviders.rent && 
+              <div className='rent__providers'>
+              <div className='film__minor-info'>
+                <span className='helper__blue'>Rent: </span>
+              </div>
+            {watchProviders.rent.map((provider: any) => (
+              <img
+                key={provider.provider_id}
+                src={getIconURL(provider.logo_path)}
+                alt={provider.provider_name + ' logo'}
+              />
+            ))}
+            </div>
+
+            }
+
 
         </div>
 

--- a/src/components/Film.tsx
+++ b/src/components/Film.tsx
@@ -59,7 +59,7 @@ const Film = () => {
         cancelled = true;
       }
       
-  }, [filmData]);
+  }, [filmData, film_id]);
 
   console.log(watchProviders)
 
@@ -80,7 +80,7 @@ const Film = () => {
         cancelled = true;
       }
       
-  }, [filmData]);
+  }, [filmData, film_id]);
 
   console.log(similarFilms)
 


### PR DESCRIPTION
If data exists, Film details page now contains 'Buy' and 'Rent' providers in addition to 'Stream'.

<img width="591" alt="Screenshot 2022-12-30 at 12 08 12" src="https://user-images.githubusercontent.com/110059340/210068782-e607e2fe-1f30-40f6-a8b0-404f7102677a.png">
